### PR TITLE
Fix rrl for huge files.

### DIFF
--- a/main.go
+++ b/main.go
@@ -523,7 +523,7 @@ func main() {
 		var data [][]string
 		rrl, err := os.Open(cLOG)
 		if err != nil {
-			lib.Panic("Missing rr.json.")
+			lib.Panicf("Missing %s.", cLOG)
 			os.Exit(1)
 		}
 		var maxSz int
@@ -531,7 +531,7 @@ func main() {
 		scanner := bufio.NewScanner(rrl)
 		rrlInfo, err := rrl.Stat()
 		if err != nil {
-			lib.Panic("Unable to open rr.json.")
+			lib.Panicf("Unable to open %s.", cLOG)
 			os.Exit(1)
 		}
 		maxSz = int(rrlInfo.Size())

--- a/main.go
+++ b/main.go
@@ -520,17 +520,23 @@ func main() {
 			"Duration",
 			"Result",
 		}
-		const maxLn = 512 * 1024
 		var data [][]string
 		rrl, err := os.Open("rr.json")
 		if err != nil {
 			lib.Panic("Missing rr.json.")
 			os.Exit(1)
 		}
+		var maxSz int
 		defer rrl.Close()
 		scanner := bufio.NewScanner(rrl)
-		buf := make([]byte, maxLn)
-		scanner.Buffer(buf, maxLn)
+		rrlInfo, err := rrl.Stat()
+		if err != nil {
+			lib.Panic("Unable to open rr.json.")
+			os.Exit(1)
+		}
+		maxSz = int(rrlInfo.Size())
+		buf := make([]byte, 0, maxSz)
+		scanner.Buffer(buf, maxSz)
 		for scanner.Scan() {
 			log := make(map[string]string)
 			json.Unmarshal(scanner.Bytes(), &log)

--- a/main.go
+++ b/main.go
@@ -521,7 +521,7 @@ func main() {
 			"Result",
 		}
 		var data [][]string
-		rrl, err := os.Open("rr.json")
+		rrl, err := os.Open(cLOG)
 		if err != nil {
 			lib.Panic("Missing rr.json.")
 			os.Exit(1)


### PR DESCRIPTION
Get the actual size of rr.json so we don't have to set a static size.